### PR TITLE
feat(exporter): don't export figma-only variables

### DIFF
--- a/packages/module/build.js
+++ b/packages/module/build.js
@@ -31,7 +31,7 @@ const build = (selector) => {
       token.attributes.type === 'icon' ||
       token.attributes.type === 'breakpoint' ||
       (token.attributes.type === 'box-shadow' && token.attributes.item !== 'color') ||
-      token.attributes.type === 'font',
+      (token.attributes.type === 'font' && token.attributes.item === 'size'),
     transformer: (token) => `${token.value}px`
   });
 

--- a/packages/module/plugins/export-patternfly-tokens/code.js
+++ b/packages/module/plugins/export-patternfly-tokens/code.js
@@ -45,6 +45,11 @@ function processCollection({ name, modes, variableIds }) {
     variableIds.forEach((variableId) => {
       const { name, resolvedType, valuesByMode } =
         figma.variables.getVariableById(variableId);
+
+      if (name.includes("figma-only")) {
+        return; // Skip this variable
+      }
+
       const value = valuesByMode[mode.modeId];
 
       if (value !== undefined && ["COLOR", "FLOAT", "STRING"].includes(resolvedType)) {


### PR DESCRIPTION
Fixes #61 

This will ignore variables that include "figma-only"
To test, use a branch of the tokens figma file that has figma-only files and run the exporter. Check that there are no tokens with "figma-only" in the name and that all others are still there.