### PR TITLE
fix: Update sortvalue to move lower in nav

### DIFF
--- a/packages/module/patternfly-docs/content/all-patternfly-tokens.md
+++ b/packages/module/patternfly-docs/content/all-patternfly-tokens.md
@@ -2,6 +2,7 @@
 section: foundations-and-styles
 subsection: design-tokens
 id: All design tokens
+sortValue: 5
 ---
 
 import * as defaultTokens from './token-layers-default.json';


### PR DESCRIPTION
Part of https://github.com/patternfly/patternfly-org/issues/4678

Attempt to fix, because this page is appearing at the top of the nav list, even when org pages have a sortValue of 1